### PR TITLE
Display screen names on the Actions page.

### DIFF
--- a/blocktogether.js
+++ b/blocktogether.js
@@ -365,7 +365,12 @@ app.get('/actions',
   function(req, res) {
     req.user
       .getActions({
-        order: 'updatedAt DESC'
+        order: 'updatedAt DESC',
+        // Get the associated TwitterUser so we can display screen names.
+        include: [{
+          model: TwitterUser,
+          required: false
+        }]
       }).error(function(err) {
         logger.error(err);
       }).success(function(actions) {

--- a/setup.js
+++ b/setup.js
@@ -192,7 +192,11 @@ var Action = sequelize.define('Action', {
   cause: Sequelize.STRING,
   cause_uid: Sequelize.STRING
 });
+// From a BtUser we want to get a list of Actions.
 BtUser.hasMany(Action, {foreignKey: 'source_uid'});
+// And from an Action we want to get a TwitterUser (to show screen name).
+Action.belongsTo(TwitterUser, {foreignKey: 'sink_uid'});
+
 _.extend(Action, {
   // Constants for the valid values of `status'.
   PENDING: 'pending',
@@ -253,7 +257,6 @@ BtUser.find({
   logger.error(err);
 }).success(function(user) {
   _.assign(userToFollow, user);
-  logger.info("ok", user);
 });
 
 module.exports = {

--- a/templates/actions.mustache
+++ b/templates/actions.mustache
@@ -15,8 +15,16 @@
     <tr class='action' data-id='{{id}}'>
       <td>{{type}}</td>
       <td>
+      {{! If TwitterUser is available and has a screen name, use that. }}
+      {{#twitterUser.screen_name}}
+        <a href='https://mobile.twitter.com/{{twitterUser.screen_name}}'
+           class='screen-name'>{{twitterUser.screen_name}}</a>
+      {{/twitterUser.screen_name}}
+      {{^twitterUser.screen_name}}
+        {{! Otherwise, use uid. }}
         <a href='https://twitter.com/intent/user?user_id={{sink_uid}}'
           >{{sink_uid}}</a>
+      {{/twitterUser.screen_name}}
       </td>
       <td>{{status}}</td>
       <td title="{{createdAt}}">{{prettyCreated}}</td>


### PR DESCRIPTION
Also add a necessary association from Actions to TwitterUsers.

cc @BooDoo for code review.
