### PR TITLE
Add config/config.json (for use by sequelize)

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -1,0 +1,18 @@
+{
+  "development": {
+    "username": "blocktogether",
+    "password": "XXXXXXXXXX",
+    "database": "blocktogether",
+    "host": "localhost",
+    "dialect": "mysql",
+    "dialectOptions": {"charset": "utf8mb4"}
+  },
+  "production": {
+    "username": "blocktogether",
+    "password": "XXXXXXXXXX",
+    "database": "blocktogether",
+    "host": "localhost",
+    "dialect": "mysql",
+    "dialectOptions": {"charset": "utf8mb4"}
+  }
+}


### PR DESCRIPTION
Minimum-viable `config/config.json`. Addresses #32.  

Points to the same `blocktogether` database whether environment is `production` or `development`  

Next steps: any harm in extending `development` and `production` objects to include blocktogether-specific values to create a unitary `config.json`?
