### PR TITLE
Retrieve only those users that haven't been updated lately from the DB

### DIFF
--- a/migrations/201410120314-index-btuser-creation.js
+++ b/migrations/201410120314-index-btuser-creation.js
@@ -1,10 +1,10 @@
 module.exports = {
   up: function(migration, DataTypes, done) {
-    migration.addIndex('BtUsers', ['updatedAt']);
+    migration.addIndex('BtUsers', ['deactivatedAt', 'updatedAt']);
     done()
   },
   down: function(migration, DataTypes, done) {
-    migration.removeIndex('BtUsers', ['updatedAt']);
+    migration.removeIndex('BtUsers', ['deactivatedAt', 'updatedAt']);
     done()
   }
 }

--- a/update-blocks.js
+++ b/update-blocks.js
@@ -21,7 +21,7 @@ var ONE_DAY_IN_MILLIS = 86400 * 1000;
 function findAndUpdateBlocks() {
   BtUser
     .find({
-      where: ["BtUsers.updatedAt < DATE_SUB(NOW(), INTERVAL 1 DAY) OR BtUsers.updatedAd IS NULL"],
+      where: ["(updatedAt < DATE_SUB(NOW(), INTERVAL 1 DAY) OR updatedAt IS NULL) AND deactivatedAt IS NULL"],
       order: 'BtUsers.updatedAt ASC'
     }).error(function(err) {
       logger.error(err);


### PR DESCRIPTION
Pulling every user is going to be a painful table scan, plus a sort by an unindexed column, means this query is not going to scale well. So we have the DB filter what users are returned!
