### PR TITLE
Add foreign key constraints to cascade deletes.

### DIFF
--- a/migrations/20141005215942-cascade-deletes.js
+++ b/migrations/20141005215942-cascade-deletes.js
@@ -3,15 +3,21 @@ module.exports = {
     // Blocks get deleted when their BlockBatch gets deleted.
     migration.queryInterface.sequelize.query(
       'ALTER TABLE Blocks ADD ' +
-      'CONSTRAINT `Blocks_ibfk_1` FOREIGN KEY (`BlockBatchId`) REFERENCES `BlockBatches` (`id`) ON DELETE CASCADE;');
+      'CONSTRAINT `Blocks_ibfk_1` FOREIGN KEY (`BlockBatchId`) ' +
+      'REFERENCES `BlockBatches` (`id`) ' +
+      'ON DELETE CASCADE ON UPDATE CASCADE;');
     // BlockBatches get deleted when their BtUser gets deleted.
     migration.queryInterface.sequelize.query(
       'ALTER TABLE BlockBatches ADD ' +
-      'CONSTRAINT `BlockBatches_ibfk_1` FOREIGN KEY (`source_uid`) REFERENCES `BtUsers` (`uid`) ON DELETE CASCADE;');
+      'CONSTRAINT `BlockBatches_ibfk_1` FOREIGN KEY (`source_uid`) ' +
+      'REFERENCES `BtUsers` (`uid`) ' +
+      'ON DELETE CASCADE ON UPDATE CASCADE;');
     // Actions get deleted when their source BtUser gets deleted.
     migration.queryInterface.sequelize.query(
       'ALTER TABLE Actions ADD ' +
-      'CONSTRAINT `Actions_ibfk_1` FOREIGN KEY (`source_uid`) REFERENCES `BtUsers` (`uid`) ON DELETE CASCADE;');
+      'CONSTRAINT `Actions_ibfk_1` FOREIGN KEY (`source_uid`) ' +
+      'REFERENCES `BtUsers` (`uid`) ' +
+      'ON DELETE CASCADE ON UPDATE CASCADE;');
     done()
   },
   down: function(migration, DataTypes, done) {


### PR DESCRIPTION
cc @mgpcoe for code review.

The intended behavior is for blocks to be deleted when we delete block batches; and for all of a user's data to be deleted when we delete the BtUser.

I've never worked with foreign key constraints before. Please be nitpicky.
