### PR TITLE
CRITICAL: Correct flaw in destroyOldBlocks

### DIFF
--- a/update-blocks.js
+++ b/update-blocks.js
@@ -295,7 +295,9 @@ function recordUnblocksUnlessDeactivated(source_uid, sink_uids) {
  */
 function destroyOldBlocks(userId) {
   BlockBatch.findAll({
-    source_uid: userId,
+    where: {
+      source_uid: userId
+    },
     offset: 4,
     order: 'id DESC'
   }).error(function(err) {


### PR DESCRIPTION
Had .destroy() call signature (implied `where`) for a findAll() call.
