### PR TITLE
Adds daily log rotation for production.

### DIFF
--- a/config/production/log4js.json
+++ b/config/production/log4js.json
@@ -4,8 +4,10 @@
     "level": "INFO",
     "category": "blocktogether",
     "appender": {
-      "type": "file",
+      "type": "dateFile",
       "filename": "blocktogether-info.log",
+      "pattern": "-dd.log",
+      "alwaysIncludePattern": false,
       "layout": { "type": "colored" }
     }
   }, {
@@ -13,8 +15,10 @@
     "level": "INFO",
     "category": "stream",
     "appender": {
-      "type": "file",
+      "type": "dateFile",
       "filename": "stream-info.log",
+      "pattern": "-dd.log",
+      "alwaysIncludePattern": false,
       "layout": { "type": "colored" }
     }
   }, {
@@ -22,8 +26,10 @@
     "level": "INFO",
     "category": "actions",
     "appender": {
-      "type": "file",
+      "type": "dateFile",
       "filename": "actions-info.log",
+      "pattern": "-dd.log",
+      "alwaysIncludePattern": false,
       "layout": { "type": "colored" }
     }
   }, {
@@ -31,8 +37,10 @@
     "level": "INFO",
     "category": "update-users",
     "appender": {
-      "type": "file",
+      "type": "dateFile",
       "filename": "update-users-info.log",
+      "pattern": "-dd.log",
+      "alwaysIncludePattern": false,
       "layout": { "type": "colored" }
     }
   }, {
@@ -40,8 +48,10 @@
     "level": "INFO",
     "category": "update-blocks",
     "appender": {
-      "type": "file",
+      "type": "dateFile",
       "filename": "update-blocks-info.log",
+      "pattern": "-dd.log",
+      "alwaysIncludePattern": false,
       "layout": { "type": "colored" }
     }
   }, {
@@ -49,8 +59,10 @@
     "level": "WARN",
     "category": "blocktogether",
     "appender": {
-      "type": "file",
+      "type": "dateFile",
       "filename": "blocktogether-warn.log",
+      "pattern": "-dd.log",
+      "alwaysIncludePattern": false,
       "layout": { "type": "colored" }
     }
   }, {
@@ -58,8 +70,10 @@
     "level": "WARN",
     "category": "stream",
     "appender": {
-      "type": "file",
+      "type": "dateFile",
       "filename": "stream-warn.log",
+      "pattern": "-dd.log",
+      "alwaysIncludePattern": false,
       "layout": { "type": "colored" }
     }
   }, {
@@ -67,8 +81,10 @@
     "level": "WARN",
     "category": "actions",
     "appender": {
-      "type": "file",
+      "type": "dateFile",
       "filename": "actions-warn.log",
+      "pattern": "-dd.log",
+      "alwaysIncludePattern": false,
       "layout": { "type": "colored" }
     }
   }, {
@@ -76,8 +92,10 @@
     "level": "WARN",
     "category": "update-users",
     "appender": {
-      "type": "file",
+      "type": "dateFile",
       "filename": "update-users-warn.log",
+      "pattern": "-dd.log",
+      "alwaysIncludePattern": false,
       "layout": { "type": "colored" }
     }
   }, {
@@ -85,8 +103,10 @@
     "level": "WARN",
     "category": "update-blocks",
     "appender": {
-      "type": "file",
+      "type": "dateFile",
       "filename": "update-blocks-warn.log",
+      "pattern": "-dd.log",
+      "alwaysIncludePattern": false,
       "layout": { "type": "colored" }
     }
   }],


### PR DESCRIPTION
Addresses Issue #125 - "Implement log rotation". Changes the production log4js configuration to replace 1 file per log with a rotation of 1 file per day per log.

Feel free to reject this pull req. if you think the rollover cornercase mentioned in the commit msg might cause issues.