### PR TITLE
Fixes #148 - pass csrf_token to template ctx.

### DIFF
--- a/blocktogether.js
+++ b/blocktogether.js
@@ -295,6 +295,7 @@ app.get('/logout',
 app.get('/logged-out',
   function(req, res) {
     var stream = mu.compileAndRender('logged-out.mustache', {
+      csrf_token: req.session.csrf
     });
     res.header('Content-Type', 'text/html');
     stream.pipe(res);


### PR DESCRIPTION
logged-out.mustache compileAndRender call was not receiving the csrf_token from the req.session. This results in bug #148 - a csrf token error if you log out and then try to use the log in form from the header.

This patch gives the logged-out mustache template the csrf_token to fix bug #148 