### PR TITLE
Handle actions against suspended users better.

### DIFF
--- a/stream.js
+++ b/stream.js
@@ -261,12 +261,6 @@ function dataCallback(recipientBtUser, err, data, ret, res) {
     }
   } else if (data.event) {
     logger.debug('User', recipientBtUser, 'event', data.event);
-    // If the event target is present, it's a Twitter User object, and we should
-    // save it if we don't already have it.
-    if (data.target) {
-      updateUsers.storeUser(data.target);
-    }
-
     if (data.event === 'unblock' || data.event === 'block') {
       handleBlockEvent(recipientBtUser, data);
     }


### PR DESCRIPTION
If all pending actions are against suspended users, currently we get stuck.
This change fixes that, and incidentally fixes an issue where we called
.thenResolve() on verifyCredentials, which doesn't return a Promise.

Also, remove the storeUser call in stream, which is generally unnecessary and
causes errors to occasionally be logged when two different streams see the same
user at nearly the same time (race condition).

cc @doeg @binaryparadox @h0ke for code review.