### PR TITLE
Fixes #146 make verifyCredentials detect suspension.

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -10,7 +10,8 @@ var twitterAPI = require('node-twitter-api'),
     Q = require('q'),
     _ = require('sequelize').Utils._,
     util = require('./util'),
-    setup = require('./setup');
+    setup = require('./setup'),
+    verifyCredentials = require('./verify-credentials').verifyCredentials;
 
 var twitter = setup.twitter,
     logger = setup.logger,

--- a/actions.js
+++ b/actions.js
@@ -265,7 +265,8 @@ function processUnblocksForUser(btUser, actions) {
       // TODO: This error handling is repeated for all actions. Abstract into
       // its own function.
       if (err && (err.statusCode === 401 || err.statusCode === 403)) {
-        return btUser.verifyCredentials().thenResolve(null);
+        verifyCredentials(btUser);
+        return Q.resolve(null);
       } else if (err && err.statusCode === 404) {
         logger.info('Unblock returned 404 for inactive sink_uid',
           action.sink_uid, 'cancelling action.');
@@ -294,7 +295,8 @@ function processMutesForUser(btUser, actions) {
       return setActionStatus(action, Action.DONE);
     }).catch(function(err) {
       if (err && (err.statusCode === 401 || err.statusCode === 403)) {
-        return btUser.verifyCredentials().thenResolve(null);
+        verifyCredentials(btUser);
+        return Q.resolve(null);
       } else if (err && err.statusCode === 404) {
         logger.info('Unmute returned 404 for inactive sink_uid',
           action.sink_uid, 'cancelling action.');
@@ -336,7 +338,8 @@ function processBlocksForUser(btUser, actions) {
       return checkUnblocks(btUser, indexedFriendships, actions);
     }).catch(function (err) {
       if (err.statusCode === 401 || err.statusCode === 403) {
-        return btUser.verifyCredentials().thenResolve(null);
+        verifyCredentials(btUser)
+        return Q.resolve(null);
       } else if (err.statusCode) {
         logger.error('Error /friendships/lookup', err.statusCode, 'for',
           btUser.screen_name, err.data);
@@ -444,7 +447,8 @@ function cancelOrPerformBlock(sourceBtUser, indexedFriendships, indexedUnblocks,
         return setActionStatus(action, Action.DONE);
       }).catch(function(err) {
         if (err && (err.statusCode === 401 || err.statusCode === 403)) {
-          return sourceBtUser.verifyCredentials().thenResolve(null);
+          verifyCredentials(sourceBtUser);
+          return Q.resolve(null);
         } else if (err.statusCode) {
           logger.error('Error /blocks/create', err.statusCode,
             sourceBtUser.screen_name, sourceBtUser.uid,

--- a/actions.js
+++ b/actions.js
@@ -11,7 +11,7 @@ var twitterAPI = require('node-twitter-api'),
     _ = require('sequelize').Utils._,
     util = require('./util'),
     setup = require('./setup'),
-    verifyCredentials = require('./verify-credentials').verifyCredentials;
+    verifyCredentials = require('./verify-credentials');
 
 var twitter = setup.twitter,
     logger = setup.logger,

--- a/stream.js
+++ b/stream.js
@@ -10,7 +10,7 @@ var twitterAPI = require('node-twitter-api'),
     updateUsers = require('./update-users'),
     util = require('./util'),
     setup = require('./setup'),
-    verifyCredentials = require('./verify-credentials').verifyCredentials;
+    verifyCredentials = require('./verify-credentials');
 
 var twitter = setup.twitter,
     logger = setup.logger,

--- a/stream.js
+++ b/stream.js
@@ -9,7 +9,8 @@ var twitterAPI = require('node-twitter-api'),
     actions = require('./actions'),
     updateUsers = require('./update-users'),
     util = require('./util'),
-    setup = require('./setup');
+    setup = require('./setup'),
+    verifyCredentials = require('./verify-credentials').verifyCredentials;
 
 var twitter = setup.twitter,
     logger = setup.logger,
@@ -201,7 +202,7 @@ function endCallback(user, httpIncomingMessage) {
   var statusCode = httpIncomingMessage.statusCode;
   logger.warn('Ending stream for', user, statusCode);
   if (statusCode === 401 || statusCode === 403) {
-    user.verifyCredentials();
+    verifyCredentials(user);
     delete streams[user.uid];
   } else if (statusCode === 420) {
     // The streaming API will return 420 Enhance Your Calm
@@ -247,7 +248,7 @@ function dataCallback(recipientBtUser, err, data, ret, res) {
     if (data.disconnect.code === 6 ||
         data.disconnect.code === 13 ||
         data.disconnect.code === 14) {
-      recipientBtUser.verifyCredentials();
+      verifyCredentials(recipientBtUser);
     }
   } else if (data.warning) {
     if (data.warning.code === 'FOLLOWS_OVER_LIMIT') {

--- a/update-users.js
+++ b/update-users.js
@@ -3,6 +3,7 @@
 /** @type{SetupModule} */
 var setup = require('./setup');
 var _ = require('sequelize').Utils._;
+var verifyCredentials = require('./verify-credentials').verifyCredentials;
 
 var config = setup.config,
     twitter = setup.twitter,
@@ -55,7 +56,7 @@ function reactivateBtUsers() {
       logger.error(err);
     }).success(function(btUsers) {
       btUsers.forEach(function (btUser) {
-        btUser.verifyCredentials();
+        verifyCredentials(btUser);
       });
     });
 }

--- a/update-users.js
+++ b/update-users.js
@@ -3,7 +3,7 @@
 /** @type{SetupModule} */
 var setup = require('./setup');
 var _ = require('sequelize').Utils._;
-var verifyCredentials = require('./verify-credentials').verifyCredentials;
+var verifyCredentials = require('./verify-credentials');
 
 var config = setup.config,
     twitter = setup.twitter,

--- a/verify-credentials.js
+++ b/verify-credentials.js
@@ -1,0 +1,86 @@
+'use strict';
+(function() {
+
+var logger = require('./setup').logger,
+    twitter = require('./setup').twitter;
+
+/**
+ * Ask Twitter to verify a user's credentials. If they are not valid,
+ * store the current time in user's deactivatedAt. If they are valid, clear
+ * the user's deactivatedAt. Save the user to DB if it's changed.
+ * A user can be deactivated because of suspension, deactivation, or revoked
+ * app. Each of these states (even revocation!) can be undone, and we'd
+ * like the app to resume working normally if that happens. So instead of
+ * deleting the user when we get one of these codes, store a 'deactivatedAt'
+ * timestamp on the user object. Users with a non-null deactivatedAt
+ * get their credentials retried once per day for 30 days, after which (TOD)
+ * they should be deleted. Regular operations like checking blocks or
+ * streaming are not performed for users with non-null deactivatedAt.
+ */
+function verifyCredentials(user) {
+  twitter.account('verify_credentials', {}, user.access_token,
+    user.access_token_secret, function(err, results) {
+      if (err && err.data) {
+        // For some reason the error data is given as a string, so we have to
+        // parse it.
+        var errJson = JSON.parse(err.data);
+        if (errJson.errors &&
+            errJson.errors.some(function(e) { return e.code === 89 })) {
+          logger.warn('User', user, 'revoked app.');
+          user.deactivatedAt = new Date();
+        } else if (err.statusCode === 404) {
+          //Testing for issue #146 indicates calling verify_credentials
+          //for a suspended account will return success, not a 404. Leaving
+          //this code in-place for robustness and in case there are
+          //differences between suspended accounts we may not be aware of.
+          logger.warn('User', user, 'deactivated or suspended.')
+          user.deactivatedAt = new Date();
+        } else {
+          logger.warn('User', user, 'verify_credentials', err.statusCode);
+        }
+      } else {
+        //We need a second lookup to the users.show.json endpoint to detect
+        //suspension status for issue #146
+        twitter.users('show',
+          { user_id: user.uid },
+          user.access_token,
+          user.access_token_secret,
+          function(err, response) {
+            if (err) {
+              // Testing using a suspended account does not seem to return
+              // 403 or 404. Leaving this here for robustness, see comments
+              // in error case of verify_credentials response handler.
+              if (err.statusCode === 403 || err.statusCode === 404) {
+                logger.warn('User', user, 'is deactivated or suspended. Marking so', err.statusCode);
+                user.deactivatedAt = new Date();
+              } else {
+                logger.warn('User', user, 'unknown error on /user/lookup', err);
+              }
+            } else {
+              // Testing for #146 showed the response.suspended field to be
+              // a reliable indicator of whether an account was suspended.
+              if (response && response.suspended === true)
+              {
+                logger.warn('User', user, 'is suspended. Marking so');
+                user.deactivatedAt = new Date();
+              } else {
+                logger.info('User', user, 'has not revoked app or deactivated.');
+                user.deactivatedAt = null;
+              }
+            }
+          }
+        );
+      }
+      if (user.changed()) {
+        user.save().error(function(err) {
+          logger.error(err);
+        });
+      }
+  });
+}
+
+module.exports = {
+  verifyCredentials: verifyCredentials
+};
+
+})();

--- a/verify-credentials.js
+++ b/verify-credentials.js
@@ -79,8 +79,6 @@ function verifyCredentials(user) {
   });
 }
 
-module.exports = {
-  verifyCredentials: verifyCredentials
-};
+module.exports = verifyCredentials;
 
 })();


### PR DESCRIPTION
* Moves verifyCredentials to its own module.
* Modifies setup.js, actions.js, stream.js, and update-users.js to use the module version of verifyCredentials instead of an instance method on the user object.
* Adds an additional /users/show call in verifyCredentials() to check the response for a suspended user flag. If this flag is present the account will be set as suspended.

Given the changes in #165 that are staged to be merged to master I did not change verifyCredentials to return a promise. Happy to submit another pull req to address that requirement if needed.

CC: @jsha and @h0ke for a review :bow: 