### PR TITLE
Switch from Q.allSettled to Q.all

### DIFF
--- a/util.js
+++ b/util.js
@@ -15,13 +15,13 @@ var Q = require('q'),
  *   batch.
  * @param {Function} f Function to call on each item. Should return a Promise.
  * @return {Promise.<Array.<Object> >} A promise that resolves once all the
- *   component promises are settled.
+ *   component promises resolve, or resolves early if there is any failure.
  */
 function slowForEach(list, interval, f) {
   var promises = list.map(function(item, i) {
     return Q.delay(i * interval).then(f.bind(null, item));
   });
-  return Q.allSettled(promises);
+  return Q.all(promises);
 }
 
 module.exports = {


### PR DESCRIPTION
Q.allSettled makes it easy to silently fail, because an Error in the array of
Promises doesn't bubble up as an error in the returned Promise. Instead, the
caller has to remember to map through the returned objects checking for errors,
which is easy to forget (and which none of the callsites in Block Together do).

This caused this bug: https://github.com/jsha/blocktogether/issues/173

cc @binaryparadox @h0ke @doeg for code review.