### PR TITLE
Update Vagrant config to work.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,75 +6,46 @@ See more details at https://blocktogether.org.
 
 # Developer Setup Instructions
 
-First, make sure that you have [Vagrant](https://www.vagrantup.com/) installed.
-Then, from the blocktogether directory, run:
+First, create an app on Twitter for your local version of blocktogether:
 
-    vagrant up
+  1. Head to https://apps.twitter.com/ and click "Create New App."
 
-Second, create an app on Twitter for your local version of blocktogether:
-
-  1. Head to https://apps.twitter.com/ and click "Create New App"
-  2. Fill out form & click "Create your Twitter application". (The description and
-     website don't matter; You'll only be using this for testing. However, it is
-     important that you don't leave the 'Callback URL' blank or you won't be able to
-     log in. Fill in any arbitrary URL here - the app will override it at login time.
+  2. Fill out form & click "Create your Twitter application".
+     Important: fill in some arbitrary URL for 'Callback URL.' It will be overridden
+     by the app, but if it's empty you won't be able to log in.
+     The description and website don't matter; You'll only be using this for testing.
 
   3. Under "Application Settings" > "Access level", click "modify app permissions"
      and select "Read and Write" access. The write permission is necessary to apply
-     blocks, unblocks, and mutes. (You may need to add a phone number to your
-     account in order to get read/write permission.)
+     blocks, unblocks, and mutes. You may need to add a phone number to your
+     account in order to get read/write permission.
 
   4. After you've set the read-write permissions, click the "Keys and Access Tokens"
-     tab. (Note that changing your app's permissions will regenerate these keys.)
+     tab. Note that changing your app's permissions will regenerate these keys.
 
+  5. Copy config/development.json to ~/.btconfig.json, and edit the
+     "consumerKey" and "consumerSecret" fields to match the "Consumer Key (API
+     Key)" and "Consumer Secret (API Secret)" fields from the "Keys and Access
+     Tokens" page.
 
-Now, we'll want to save our Twitter credentials to the configfile so BlockTogether
-can access Twitter's API:
+Next, make sure that you have [Vagrant](https://www.vagrantup.com/) installed.
+From the blocktogether directory, run:
 
-  1. From the `blocktogether` directory, run `vagrant ssh`
-  2. Open the config file for editing: `sudo vim /etc/blocktogether/config.json`
-     or with your editor of choice (though you might have to apt-get it)
-  3. Replace the placeholder `consumerKey` and `consumerSecret` fields with your
-     your new credentials (found under your dev app on https://apps.twitter.com)
+    vagrant up
 
-You're now ready to run BlockTogether locally. :D Start the by first SSH'ing
-into the Vagrant box. From the root `blocktogether` directory:
+You're now ready to run Block Together locally. :D SSH into the Vagrant box and
+start the daemons:
 
     vagrant ssh
+    cd /vagrant && ./run-dev.sh
 
-And then from the Vagrant box:
-
-    cd /vagrant && ./run.sh
-
-You should now be able to access your local version of blocktogether in a browser
+You can now access your local version of Block Together in a browser
 at http://localhost:3000.
-
-Log in for the first time using the 'Log in' button (nope, not the 'Sign up' button).
-After you've authorized your app, you should be able to connect to the database
-using the credentials installed in /etc/blocktogether/config.json:
-
-    mysql -u blocktogether --password=PASSWORD -D blocktogether
-
-Extract the `access_token` and `access_token_secret` for your user:
-
-    select * from BtUsers \G
-
-Put these in /etc/blocktogether/config.json, using the same capitalization as
-the existing fields. Also change `userToFollow` to your Twitter handle.
-
-Now you can start the server & the support daemons. (The daemons perform the
-background work that the web frontend doesn't do.)
-
-     vagrant ssh
-     cd /vagrant && ./run-dev.sh
-
-You can now start developing!
 
 **Note:** It's highly recommended you create a few test accounts
 on Twitter in order to be able to exercise the sharing functionality of Block
 Together, and so that you don't create or delete blocks on your main account
 unintentionally.
-
 
 # License
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,4 +9,5 @@ Vagrant.configure("2") do |config|
   config.vm.box_url = "https://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-i386-vagrant-disk1.box"
   config.vm.provision :shell, privileged: false, path: "bin/vagrant_up.sh"
   config.vm.network :forwarded_port, host: 3000, guest: 3000
+  config.vm.provision "file", source: "~/.btconfig.json", destination: "/etc/blocktogether/config.json"
 end

--- a/bin/vagrant_up.sh
+++ b/bin/vagrant_up.sh
@@ -1,6 +1,6 @@
 # #!/bin/bash
 
-# Bootstraps the BlockTogether dev environment from a fresh Vagrant box.
+# Bootstraps the Block Together dev environment from a fresh Vagrant box.
 # Note that this will override any pre-existing config state (Twitter credentials, etc.)
 # and is NOT idempotent. (Check out setup.sh for that.)
 #
@@ -10,7 +10,7 @@ source /vagrant/bin/setup.sh
 sudo chown -R "$USER" /data/blocktogether
 
 cd /vagrant && npm install
-./node_modules/sequelize/bin/sequelize --config /etc/blocktogether/sequelize.json -m
+./node_modules/.bin/sequelize --config /etc/blocktogether/sequelize.json db:migrate
 
 echo
 echo "Vagrant bootstrap complete. Refer to the README for more setup instructions."

--- a/config/development.json
+++ b/config/development.json
@@ -6,10 +6,8 @@
   },
   "callbackUrl": "http://localhost:3000/auth/twitter/callback",
   "secureProxy": false,
-  "consumerKey": "XXXXXXXXXXXXXXXXXXXXXXXXX",
-  "consumerSecret": "YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY",
-  "cookieSecret": "__COOKIE_SECRET__",
-  "defaultAccessToken": "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
-  "defaultAccessTokenSecret": "CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC",
-  "userToFollow": "test_account"
+  "cookieSecret": "f46140502de85b9056978961f6377e0eadcfee2a",
+  "userToFollow": "test_account",
+  "consumerKey": "__CONSUMER_KEY__",
+  "consumerSecret": "__CONSUMER_SECRET__"
 }

--- a/config/production.json
+++ b/config/production.json
@@ -6,10 +6,8 @@
   },
   "callbackUrl": "https://blocktogether.org/auth/twitter/callback",
   "secureProxy": true,
-  "consumerKey": "XXXXXXXXXXXXXXXXXXXXXXXXX",
-  "consumerSecret": "YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY",
+  "userToFollow": "blocktogether",
   "cookieSecret": "__COOKIE_SECRET__",
-  "defaultAccessToken": "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
-  "defaultAccessTokenSecret": "CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC",
-  "userToFollow": "blocktogether"
+  "consumerKey": "XXXXXXXXXXXXXXXXXXXXXXXXX",
+  "consumerSecret": "YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY"
 }

--- a/run-dev.sh
+++ b/run-dev.sh
@@ -1,15 +1,16 @@
 #!/bin/bash
 cd $(dirname $0)
 run() {
-  js ${1}.js &
+  node ${1}.js &
 }
 
 trap 'pkill -P $$' EXIT
 
-run blocktogether
-run stream
-run actions
-run update-users
-run update-blocks
+run stream > /tmp/stream.log
+run actions > /tmp/actions.log
+run update-users > /tmp/update-users.log
+run update-blocks > /tmp/update-blocks.log
 
-while :; do sleep 10000 ; done
+node ./node_modules/nodemon/bin/nodemon.js -w . -e js,mustache,html,css blocktogether.js &
+
+wait

--- a/run.sh
+++ b/run.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-node ./node_modules/nodemon/bin/nodemon.js -w . -e js,mustache,html,css blocktogether.js


### PR DESCRIPTION
Update Vagrant config to work.

- Preset settings for mailutils so apt-get doesn't get hung up on prompting.
- Switch to mariadb.
- Inhibit output from openssl that otherwise spams the build log.
- Use new bin path for sequelize CLI.
- Replace run.sh with run-dev.sh.
- Remove unused defaultAccessToken fields from configs.
- Make Vagrantfile copy a starter config with Twitter credentials.
- Simplify README.