### PR TITLE
start adding integration tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "repository": "https://github.com/jsha/blocktogether.git",
   "license": "GPL-3.0",
   "version": "1.7.2",
+  "scripts": {
+    "test": "./node_modules/.bin/casperjs test test/integration/*.js"
+  },
   "dependencies": {
     "body-parser": "^1.6.7",
     "cookie-session": "^1.0.2",
@@ -21,5 +24,9 @@
     "sequelize": "^3.17.3",
     "sequelize-cli": "^1.9.2",
     "timeago": "^0.1.0"
+  },
+  "devDependencies": {
+    "casperjs": "^1.1.3",
+    "phantomjs-prebuilt": "^2.1.12"
   }
 }

--- a/test/integration/signup_logon_test.js
+++ b/test/integration/signup_logon_test.js
@@ -1,0 +1,86 @@
+var system = require('system');
+var user = system.env.BT_TEST_MAIN_USER;
+var pass = system.env.BT_TEST_MAIN_PASS;
+
+var host = 'http://localhost:3000';
+
+function checkBoxes() {
+  return [
+    document.querySelector('#block_new_accounts').checked,
+    document.querySelector('#block_low_followers').checked,
+    document.querySelector('#share_blocks').checked,
+    document.querySelector('#follow_blocktogether').checked
+  ];
+}
+
+// API docs: http://docs.casperjs.org/en/latest/testing.html
+//
+// The first argument is the name of the test, the second is the
+// number of assertions occuring in the test, and the last is the test
+// block itself.
+casper.test.begin('Sign up and log on', 5, function(test) {
+  casper.start(host, function() {
+    return this.fill('form[action*="/auth/twitter"]', {}, true);
+  });
+
+  casper.then(function() {
+    return this.fill(
+      'form[action*="https://api.twitter.com/oauth/authenticate"]',
+      // NB: must use single quotes
+      { 'session[username_or_email]': user , 'session[password]': pass }, true);
+  });
+
+  casper.waitForSelector('.container-fluid', function() {
+    var checks = this.evaluate(checkBoxes);
+
+    test.assertEqual(checks, [false, false, false, true], 'new account has default settings');
+
+    this.click('#block_new_accounts');
+
+    this.reload(function() {
+      var checks = this.evaluate(checkBoxes);
+      test.assertEqual(checks, [true, false, false, true], 'block_new_accounts was saved');
+    });
+  });
+
+  casper.then(function() {
+    casper.open(host + '/logout', function() {
+      return true;
+    });
+  });
+
+  casper.waitForSelector('.log-on-link', function() {
+    return this.fill('form[action*="/auth/twitter"]', {}, true);
+  });
+
+  casper.waitForSelector('.container-fluid', function() {
+    var checks = this.evaluate(checkBoxes);
+    test.assertEqual(checks, [true, false, false, true], 'after logging out and in, settings are preserved');
+  });
+
+  casper.then(function() {
+    casper.open(host + '/logout', function() {
+      return true;
+    });
+  });
+
+  casper.waitForSelector('.log-on-link', function() {
+    return this.click('.navbar-brand');
+  });
+
+  casper.then(function() {
+    this.click('#share_blocks');
+    return this.fill('form[action*="/auth/twitter"]', {}, true);
+  });
+
+  casper.waitForSelector('.container-fluid', function() {
+    var checks = this.evaluate(checkBoxes);
+    test.assertEqual(checks, [false, false, true, true], 'signing up again overrides old settings');
+    var text = this.getHTML();
+    test.assert(text.indexOf('unlisted, unguessable') > -1, 'there is a valid show-blocks URL');
+  });
+
+  casper.run(function() {
+    test.done();
+  });
+});

--- a/test/testing.md
+++ b/test/testing.md
@@ -1,5 +1,3 @@
-Manual tests to run before a release:
-
 ## Initial setup
 
 - With @twestact3, visit https://twitter.com/settings/applications and revoke
@@ -7,6 +5,8 @@ Manual tests to run before a release:
   production instance of Block Together.
 
 ## Sign up and log on
+
+_(Automated by `integration/signup_logon_test.js`)_
 
 - Sign up for Block Together using @twestact3 and the default settings. Visit
   settings page and ensure those settings are there.


### PR DESCRIPTION
This automates the first section of manual tests from the `testing.md` document.  I'm using CasperJS since it allows access to environment variables and is a lot easier than Nightmare or the various PhantomJS+mocha integrations.

If you're down with this idea, I can work on the rest of the tests.