### PR TITLE
new integration test: Blocking users with low followers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,15 @@ node_js:
 
 addons:
   mariadb: '5.5'
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.8
 
 env:
   global:
+    - CXX=g++-4.8
     - DB_ROOT_PASS="$(openssl rand -hex 20)"
     - APPUSER="$USER"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,5 +32,8 @@ script:
     --externs=externs/underscore-1.5.1.js > /dev/null"
   - if [ -n "$CONSUMER_KEY" ]; then npm test; fi
 
+after_script:
+  - if [ -n "$CONSUMER_KEY" ]; then npm run-script unblock; fi
+
 after_failure:
   - if [ -n "$CONSUMER_KEY" ]; then cat bt.log; fi

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "license": "GPL-3.0",
   "version": "1.7.2",
   "scripts": {
-    "test": "./node_modules/.bin/casperjs test test/integration/*.js"
+    "test": "./node_modules/.bin/casperjs test test/integration/*.js",
+    "unblock": "node unblock-all.js $BT_TEST_MAIN_USER"
   },
   "dependencies": {
     "body-parser": "^1.6.7",

--- a/test/integration/block_low_follower_users_test.js
+++ b/test/integration/block_low_follower_users_test.js
@@ -64,7 +64,7 @@ casper.test.begin('Block low follower users', 2, function(test) {
     return this.fill('form[id="update-form"]', {}, true);
   });
 
-  casper.wait(5000, function() {
+  casper.wait(15000, function() {
     casper.open('https://twitter.com/' + mainUser, function() {
       return true;
     });

--- a/test/integration/block_low_follower_users_test.js
+++ b/test/integration/block_low_follower_users_test.js
@@ -4,16 +4,10 @@ var mainPass = system.env.BT_TEST_MAIN_PASS;
 var lowUser = system.env.BT_TEST_LOW_FOLLOWER_USER;
 var lowPass = system.env.BT_TEST_LOW_FOLLOWER_PASS;
 
-var host = 'http://localhost:3000';
+var checkBoxes = require('../lib/check_boxes.js');
+var logout = require('../lib/logout.js');
 
-function checkBoxes() {
-  return [
-    document.querySelector('#block_new_accounts').checked,
-    document.querySelector('#block_low_followers').checked,
-    document.querySelector('#share_blocks').checked,
-    document.querySelector('#follow_blocktogether').checked
-  ];
-}
+var host = 'http://localhost:3000';
 
 casper.test.begin('Block low follower users', 2, function(test) {
   casper.start(host, function() {
@@ -74,13 +68,7 @@ casper.test.begin('Block low follower users', 2, function(test) {
     test.assert(this.exists('.BlocksYouTimeline'), 'Low follower user is blocked');
   });
 
-  casper.thenOpen(host + '/logout', function() {
-    return true;
-  });
-
-  casper.thenOpen('https://twitter.com/logout', function() {
-    return this.fill('form[action*="/logout"]', {}, true);
-  });
+  logout(casper, host);
 
   casper.run(function() {
     test.done();

--- a/test/integration/block_low_follower_users_test.js
+++ b/test/integration/block_low_follower_users_test.js
@@ -1,0 +1,88 @@
+var system = require('system');
+var mainUser = system.env.BT_TEST_MAIN_USER;
+var mainPass = system.env.BT_TEST_MAIN_PASS;
+var lowUser = system.env.BT_TEST_LOW_FOLLOWER_USER;
+var lowPass = system.env.BT_TEST_LOW_FOLLOWER_PASS;
+
+var host = 'http://localhost:3000';
+
+function checkBoxes() {
+  return [
+    document.querySelector('#block_new_accounts').checked,
+    document.querySelector('#block_low_followers').checked,
+    document.querySelector('#share_blocks').checked,
+    document.querySelector('#follow_blocktogether').checked
+  ];
+}
+
+casper.test.begin('Block low follower users', 2, function(test) {
+  casper.start(host, function() {
+    this.click('#block_low_followers');
+    return this.fill('form[action*="/auth/twitter"]', {}, true);
+  });
+
+  casper.waitForSelector('#oauth_form', function() {
+    return this.fill(
+      'form[id="oauth_form"]',
+      // NB: must use single quotes
+      { 'session[username_or_email]': mainUser, 'session[password]': mainPass }, true);
+  });
+
+  casper.waitForSelector('.container-fluid', function() {
+    var checks = this.evaluate(checkBoxes);
+    test.assertEqual(checks, [false, true, false, true], 'blocking low follower users');
+  });
+
+  casper.waitForSelector('.saved', function() {
+    casper.open('https://twitter.com/logout', function() {
+      return true;
+    });
+  });
+
+  casper.waitForSelector('.signout', function() {
+    return this.fill('form[action*="/logout"]', {}, true);
+  });
+
+  casper.thenOpen('https://twitter.com/login', function() {
+    return true;
+  });
+
+  casper.waitForSelector('.signin', function() {
+    return this.fill(
+      'form[action*="https://twitter.com/sessions"]',
+      { 'session[username_or_email]': lowUser, 'session[password]': lowPass }, true);
+  });
+
+  // Random number so we don't get blocked for duplicate tweets
+  casper.thenOpen('https://twitter.com/intent/tweet?text=@' +
+                  mainUser + ' ive got ' + Math.random() + ' problems',
+                  function() {
+                    return true;
+                  });
+
+  casper.waitForSelector('#update-form', function() {
+    return this.fill('form[id="update-form"]', {}, true);
+  });
+
+  casper.wait(5000, function() {
+    casper.open('https://twitter.com/' + mainUser, function() {
+      return true;
+    });
+  });
+
+  casper.waitForSelector('.dropdown', function() {
+    test.assert(this.exists('.BlocksYouTimeline'), 'Low follower user is blocked');
+  });
+
+  casper.thenOpen(host + '/logout', function() {
+    return true;
+  });
+
+  casper.thenOpen('https://twitter.com/logout', function() {
+    return this.fill('form[action*="/logout"]', {}, true);
+  });
+
+  casper.run(function() {
+    test.done();
+  });
+});

--- a/test/integration/signup_logon_test.js
+++ b/test/integration/signup_logon_test.js
@@ -2,16 +2,10 @@ var system = require('system');
 var user = system.env.BT_TEST_MAIN_USER;
 var pass = system.env.BT_TEST_MAIN_PASS;
 
-var host = 'http://localhost:3000';
+var checkBoxes = require('../lib/check_boxes.js');
+var logout = require('../lib/logout.js');
 
-function checkBoxes() {
-  return [
-    document.querySelector('#block_new_accounts').checked,
-    document.querySelector('#block_low_followers').checked,
-    document.querySelector('#share_blocks').checked,
-    document.querySelector('#follow_blocktogether').checked
-  ];
-}
+var host = 'http://localhost:3000';
 
 // Sometimes Twitter will immediately redirect back to the Block Together, but
 // sometimes it will show an interstitial with an "Authorize" button even though
@@ -96,13 +90,7 @@ casper.test.begin('Sign up and log on', 6, function(test) {
     test.assert(text.indexOf('unlisted, unguessable') > -1, 'there is a valid show-blocks URL');
   });
 
-  casper.thenOpen(host + '/logout', function() {
-    return true;
-  });
-
-  casper.thenOpen('https://twitter.com/logout', function() {
-    return this.fill('form[action*="/logout"]', {}, true);
-  });
+  logout(casper, host);
 
   casper.run(function() {
     test.done();

--- a/test/integration/signup_logon_test.js
+++ b/test/integration/signup_logon_test.js
@@ -96,6 +96,14 @@ casper.test.begin('Sign up and log on', 6, function(test) {
     test.assert(text.indexOf('unlisted, unguessable') > -1, 'there is a valid show-blocks URL');
   });
 
+  casper.thenOpen(host + '/logout', function() {
+    return true;
+  });
+
+  casper.thenOpen('https://twitter.com/logout', function() {
+    return this.fill('form[action*="/logout"]', {}, true);
+  });
+
   casper.run(function() {
     test.done();
   });

--- a/test/integration/signup_logon_test.js
+++ b/test/integration/signup_logon_test.js
@@ -59,10 +59,8 @@ casper.test.begin('Sign up and log on', 6, function(test) {
     });
   });
 
-  casper.then(function() {
-    casper.open(host + '/logout', function() {
-      return true;
-    });
+  casper.thenOpen(host + '/logout', function() {
+    return true;
   });
 
   casper.waitForSelector('.log-on-link', function() {
@@ -76,10 +74,8 @@ casper.test.begin('Sign up and log on', 6, function(test) {
     test.assertEqual(checks, [true, false, false, true], 'after logging out and in, settings are preserved');
   });
 
-  casper.then(function() {
-    casper.open(host + '/logout', function() {
-      return true;
-    });
+  casper.thenOpen(host + '/logout', function() {
+    return true;
   });
 
   casper.waitForSelector('.log-on-link', function() {

--- a/test/lib/check_boxes.js
+++ b/test/lib/check_boxes.js
@@ -1,0 +1,8 @@
+module.exports = function checkBoxes() {
+  return [
+    document.querySelector('#block_new_accounts').checked,
+    document.querySelector('#block_low_followers').checked,
+    document.querySelector('#share_blocks').checked,
+    document.querySelector('#follow_blocktogether').checked
+  ];
+}

--- a/test/lib/logout.js
+++ b/test/lib/logout.js
@@ -1,0 +1,9 @@
+module.exports = function(casper, host) {
+  casper.thenOpen(host + '/logout', function() {
+    return true;
+  });
+
+  casper.thenOpen('https://twitter.com/logout', function() {
+    return this.fill('form[action*="/logout"]', {}, true);
+  });
+};

--- a/test/testing.md
+++ b/test/testing.md
@@ -64,6 +64,8 @@ _(Automated by `integration/signup_logon_test.js`)_
 
 ## Blocking low follower users
 
+_(Automated by `integration/block_low_follower_users_test.js`)_
+
 - Log on with @twestact3, enable block_low_followers.
 - Ensure @twestact6 has < 15 followers.
 - Using @twestact6, @-mention @twestact3.


### PR DESCRIPTION
The way I did this requires four new env variables:
- `BT_TEST_LOW_FOLLOWER_USER` (a user with < 15 followers)
- `BT_TEST_LOW_FOLLOWER_PASS`
- `ACCESS_TOKEN`
- `ACCESS_SECRET`

The last two are so we can use the Twitter API directly to unblock the low-followers user after the tests, since doing it through the web UI via Casper didn't work.