### PR TITLE
Remove auto-block features from index

### DIFF
--- a/templates/index.mustache
+++ b/templates/index.mustache
@@ -44,18 +44,6 @@
     Together without sharing your blocks with anyone.
     </p>
 
-    <p>
-    Sometimes, attackers who get blocked will create new
-    accounts (called "<a
-    href='http://en.wikipedia.org/wiki/Sockpuppet_(Internet)'>sockpuppets</a>")
-    to get around the block. To deal with sockpuppet accounts, Block Together
-    has options to let you auto-block accounts meeting certain criteria: created
-    less than seven days ago and/or having fewer than 15 followers. Block
-    Together uses Twitter's Streaming API to find such accounts when they
-    mention you, so it can usually block them in under a second. You don't need
-    to stay logged in for this to work.
-    </p>
-
     <a name='incorrect-blocks' href='#incorrect-blocks'>
     <h3>Protections from incorrect blocks</h3>
     </a>


### PR DESCRIPTION
Since the auto-block features are disabled, they shouldn't be advertised on the main page.